### PR TITLE
[Feature] Dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+.DS_Store

--- a/R/ft_colors.R
+++ b/R/ft_colors.R
@@ -1,4 +1,3 @@
-
 # FT Origami Colours
 # https://registry.origami.ft.com/components/o-colors@4.9.0
 ft_o_colors <- c(
@@ -57,7 +56,16 @@ ft_o_colors <- c(
   `teal-70` = "#12A5B3",
   `teal-80` = "#14BDCC",
   `teal-90` = "#17D4E6",
-  `teal-100` = "#1AECFF"
+  `teal-100` = "#1AECFF",
+  `linesocial-axis-lines` = "#52555B",
+  `linesocial-background-slate` = "#272A32",
+  `linesocial-text` = "#B8B8B8",
+  `linesocial-red` = "#FF0055",
+  `linesocial-blue` = "#0066FF",
+  `linesocial-green` = "#B1E645",
+  `linesocial-lightblue` = "#00CCFF",
+  `linesocial-offwhite` = "#F2E5DA",
+  `linesocial-grey` = "#65798C"
 )
 
 ft_colors <- function(...){
@@ -104,7 +112,9 @@ ft_o_palettes <- list(
   `white` = ft_colors("white-10","white-20","white-40","white-60","white-80"),
   `claret` = ft_colors("claret-30","claret-40","claret-50","claret-60","claret-70","claret-80","claret-90","claret-100"),
   `oxford` = ft_colors("oxford-30","oxford-40","oxford-50","oxford-60","oxford-70","oxford-80","oxford-90","oxford-100"),
-  `teal` = ft_colors("teal-20","teal-30","teal-40","teal-50","teal-60","teal-70","teal-80","teal-90","teal-100")
+  `teal` = ft_colors("teal-20","teal-30","teal-40","teal-50","teal-60","teal-70","teal-80","teal-90","teal-100"),
+  `dark main` = ft_colors("linesocial-axis-lines","linesocial-background-slate","linesocial-text"),
+  `dark primary` = ft_colors("linesocial-red","linesocial-blue","linesocial-green","linesocial-lightblue","linesocial-offwhite","linesocial-grey")
 )
 
 

--- a/R/ft_theme.R
+++ b/R/ft_theme.R
@@ -2,6 +2,7 @@
 #' @param legend_right Logical indicating whether legend should be placed to
 #' the right of the plot. If FALSE, the default, legend is positioned above the
 #' plot.
+#' @param theme_dark Logical indicating whether to use the dark color scheme
 #' @param base_size The base font size
 #' @param base_family Font family
 #' @param base_line_size Default
@@ -19,7 +20,14 @@
 #'   facet_wrap(vars(class)) +
 #'   ft_theme()
 #'
+
+library(ggplot2)
+ggplot(mpg, aes(displ, hwy, color = class)) +
+  geom_point() +
+  ft_theme()
+
 ft_theme <- function(legend_right = FALSE,
+                     theme_dark = FALSE,
                      base_size = 12,
                      base_family = "",
                      base_line_size = base_size / 170,
@@ -41,6 +49,13 @@ ft_theme <- function(legend_right = FALSE,
     spec_legend_direction <- "horizontal"
     legend_justification_spec <- c(0,0)
     legend_box_spacing_spec <- ggplot2::unit(0, "char")
+  }
+
+  if(theme_dark == TRUE){
+    grid_line_color <- ft_colors_a("linesocial-axis-lines")
+    title_text_color <- ft_colors_a("white")
+    other_text_color <- ft_colors_a("linesocial-text")
+    background_color <- ft_colors_a("linesocial-background-slate")
   }
 
   ggplot2::theme_minimal(base_size = base_size,
@@ -111,4 +126,3 @@ ft_theme <- function(legend_right = FALSE,
       complete = TRUE
     )
 }
-


### PR DESCRIPTION
## Description

Adding a dark theme option to `ft_theme()`.

Unfortunately the contrast on most of the meeting room displays is up so high that the white background of the default theme blows out all the other colours making it very hard for people to read. So introducing...Dark theme! (before 2019 is over) 

## Implementation

I spoke to Interactive Graphics as they share 'dark theme' charts on the FT twitter account. They linked me to the their colour palette (lineSocial) and I transplanted them into `ft_colours()`. 

I've also added a `theme_dark` (default = false) option the `ft_theme` function to enable this feature.

```
ft_theme(theme_dark = TRUE)
```

## Screenshot

![Default theme (current)](https://user-images.githubusercontent.com/1937725/68317437-028a8580-00b3-11ea-8bf8-88a7aef3ebe6.png)

![New dark theme](https://user-images.githubusercontent.com/1937725/68317440-04ecdf80-00b3-11ea-8078-54c20bf4d630.png)


