### PR TITLE
Spacing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: ftplottools
-Version: 0.1.3
+Version: 0.1.4
 Date: 2019-08-06
 Title: Styles for FT Graphs
 Authors@R: person("Oliver", "Elliott", email = "oliver.elliott@ft.com", role = c("aut","cre"))

--- a/R/ft_theme.R
+++ b/R/ft_theme.R
@@ -63,7 +63,8 @@ ft_theme <- function(legend_right = FALSE,
       plot.caption = ggplot2::element_text(
         color = other_text_color,
         hjust = 0,
-        size = ggplot2::rel(0.8)
+        size = ggplot2::rel(0.8),
+        margin = margin(t = half_line)
       ),
       axis.title = ggplot2::element_text(
         color = other_text_color,

--- a/R/ft_theme.R
+++ b/R/ft_theme.R
@@ -51,13 +51,14 @@ ft_theme <- function(legend_right = FALSE,
         color = title_text_color,
         size = ggplot2::rel(1.2),
         face = "bold",
-        hjust = 0
+        hjust = 0,
+        margin = ggplot2::margin(b = half_line)
       ),
       plot.subtitle = ggplot2::element_text(
         color = other_text_color,
         face = "bold",
         hjust = 0,
-        margin = ggplot2::margin(t = half_line)
+        margin = ggplot2::margin(b = half_line)
       ),
       plot.caption = ggplot2::element_text(
         color = other_text_color,

--- a/R/ft_theme.R
+++ b/R/ft_theme.R
@@ -76,6 +76,7 @@ ft_theme <- function(legend_right = FALSE,
         size = ggplot2::rel(0.8),
         margin = ggplot2::margin()
       ),
+      axis.text.y = ggplot2::element_text(margin = ggplot2::margin(r = -0.8 * half_line / 2), hjust = 1),
       axis.line = ggplot2::element_line(
         colour = grid_line_color,
         size = grid_line_size

--- a/R/ft_theme.R
+++ b/R/ft_theme.R
@@ -84,7 +84,7 @@ ft_theme <- function(legend_right = FALSE,
         size = grid_line_size
       ),
       axis.ticks.y = ggplot2::element_blank(),
-      axis.ticks.length = ggplot2::unit(1,"char"),
+      axis.ticks.length = ggplot2::unit(0.5,"char"),
       panel.grid.major.y = ggplot2::element_line(
         color = grid_line_color,
         size = grid_line_size


### PR DESCRIPTION
This pull request implements a few changes to the placement of the components of the output plots:
1. Titles and subtitles now have a bottom margin. The previous subtitle top margin has been removed.
2. A top margin for the caption has been added.
3. The x-axis tick length has been reduced from a full character length to a half character length.
4. The y-axis text has been moved closer to the plot area to eliminate unnecessary whitespace.

To see the effect of these changes in action, see #7.

All changes are behind-the-scenes so documentation all remains as is.

The version number has been incremented.
