### PR TITLE
Darker text and plot-aligned titles and captions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: ftplottools
-Version: 0.1.4
+Version: 0.1.5
 Date: 2019-08-06
 Title: Styles for FT Graphs
 Authors@R: person("Oliver", "Elliott", email = "oliver.elliott@ft.com", role = c("aut","cre"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ License: file LICENSE
 LazyData: TRUE
 RoxygenNote: 6.1.1
 Imports: 
-    ggplot2,
+    ggplot2 (>= 2.3.3),
     assertthat,
     magrittr
 Repository: FTRAN

--- a/R/ft_theme.R
+++ b/R/ft_theme.R
@@ -110,6 +110,8 @@ ft_theme <- function(legend_right = FALSE,
       legend.margin = ggplot2::margin(),
       legend.box.spacing = legend_box_spacing_spec,
       plot.margin = ggplot2::margin(1,1,1,1, unit = "char"),
+      plot.title.position = "plot",
+      plot.caption.position = "plot",
 
       complete = TRUE
     )

--- a/R/ft_theme.R
+++ b/R/ft_theme.R
@@ -29,7 +29,7 @@ ft_theme <- function(legend_right = FALSE,
   grid_line_color <- ft_colors("black-20")
   grid_line_size <- 0.2
   title_text_color <- ft_colors("black")
-  other_text_color <- ft_colors("black-50")
+  other_text_color <- ft_colors("black-70")
 
   if(legend_right == TRUE){
     spec_legend_position <- "right"


### PR DESCRIPTION
This pull request makes two changes:

1. Plot titles and captions are now aligned to the plot rather than to the panel. This behaviour is enabled by the recent CRAN release of ggplot2 2.3.3  (#9)  .

2. Text is now darker such that it passes the Web Content Accessibility Guidelines (WCAG). Fixes #10.

Version number is incremented.